### PR TITLE
arreglado tamaño de texto en listas

### DIFF
--- a/theme/templates/main.less
+++ b/theme/templates/main.less
@@ -323,10 +323,6 @@ article {
     p {
         font-size: 2em;
     }
-
-    li {
-        font-size: 2em;
-    }
 }
 
 .list {


### PR DESCRIPTION
Pequeño arreglo que modifica el css para que el texto en las listas no tengan el doble de tamaño.

Antes:
![image](https://user-images.githubusercontent.com/3670355/45595069-2e761380-b9a6-11e8-9658-a4d9ea50ad26.png)

Despues:
![image](https://user-images.githubusercontent.com/3670355/45595072-46e62e00-b9a6-11e8-8abd-f9e0b84d30e7.png)
